### PR TITLE
fix dockerfile line attempt

### DIFF
--- a/_infra/docker/Dockerfile
+++ b/_infra/docker/Dockerfile
@@ -10,5 +10,5 @@ COPY . /app
 RUN pipenv install --deploy --system
 
 EXPOSE 5051
-CMD ["gunicorn", "-c", "gunicorn.py", "app:app"]
+CMD ["gunicorn", "-c", "gunicorn.py", "application:create_app()"]
 

--- a/_infra/helm/secure-message-v2/Chart.yaml
+++ b/_infra/helm/secure-message-v2/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.2
+appVersion: 0.0.3


### PR DESCRIPTION
# What and why?
My previous attempt at fixing the kubernetes deployment with this app failed, because although it found the gunicorn config, the pod was crashing with an error about not being able to find a module called `app`. I looked up what the issue was, and from what I could gather, the gunicorn command in the Dockerfile wasn't correct because it needed to point to the file and function responsible for creating the app (which in this case is in the `application.py` file, and the function is called `create_app()`). As such, the parameter (I presume) it wants at the end of the command should be `application:create_app()`. This PR makes this change, which should make the deployment work, fingers crossed.

# How to test?

# Jira
[Card](https://jira.ons.gov.uk/browse/RAS-297)