### PR TITLE
RAS-850 Cloud sql proxy term timeout and verbose

### DIFF
--- a/_infra/helm/secure-message-v2/Chart.yaml
+++ b/_infra/helm/secure-message-v2/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.9
+version: 0.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.9
+appVersion: 0.0.10

--- a/_infra/helm/secure-message-v2/templates/deployment.yaml
+++ b/_infra/helm/secure-message-v2/templates/deployment.yaml
@@ -39,7 +39,9 @@ spec:
           command: ["/cloud_sql_proxy",
                     "-instances=$(SQL_INSTANCE_NAME)=tcp:$(DB_PORT)",
                     "-ip_address_types=PRIVATE",
-                    "-credential_file=/secrets/cloudsql/credentials.json"]
+                    "-credential_file=/secrets/cloudsql/credentials.json",
+                    "-term_timeout=30s",
+                    "-verbose=false"]
           securityContext:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false


### PR DESCRIPTION
# What and why?
This PR adds a wait time for cloud_sql_proxy and stops verbose logging. Currently we deploy the app with a side car cloud_sql_proxy container to access the db. However when a pod is redeployed and the proxy container is sent a SIGTERM the container does not close down gracefully and will kill all connections instantly (i.e sql queries). This naturally gets passed back up the chain to the respondent who will get an error. With us currently using a default pool of 5 and overflow of 10, it means anything up to 15 respondents could get an error when we deploy a new release to prod, which ain't good.
It almost certainly is the reason we see hanging queries and spikes on rollouts in Grafana. This PR adds a term_timeout which will allow the proxy to complete it's query (at least give it 30 seconds to do so) before it creates a revision.

The PR also stops verbose logging which is set by default and why we get so many records in the logs we just don't need. The logging will still show start-up and errors which is fine for what we need
# How to test?
Realistically you don't need to test this again if you have done it for this one see https://github.com/ONSdigital/ras-party/pull/401 Naturally you can, just note the components to remove will be different. 
# Jira