### PR TITLE
RAS-1172 Delete Secure Message Threads Marked for Deletion

### DIFF
--- a/_infra/helm/secure-message-v2/Chart.yaml
+++ b/_infra/helm/secure-message-v2/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.23
+version: 0.0.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.23
+appVersion: 0.0.24

--- a/_infra/helm/secure-message-v2/templates/delete-threads-scheduled-job.yaml
+++ b/_infra/helm/secure-message-v2/templates/delete-threads-scheduled-job.yaml
@@ -27,5 +27,5 @@ spec:
             command:
             - /bin/sh
             - -c
-            - curl -s -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X PATCH http://$(SECURE_MESSAGE_V2_SERVICE_HOST):$(SECURE_MESSAGE_V2_SERVICE_PORT)/$(TARGET)
+            - curl -s -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(SECURE_MESSAGE_V2_SERVICE_HOST):$(SECURE_MESSAGE_V2_SERVICE_PORT)/$(TARGET)
           restartPolicy: OnFailure

--- a/_infra/helm/secure-message-v2/templates/delete-threads-scheduled-job.yaml
+++ b/_infra/helm/secure-message-v2/templates/delete-threads-scheduled-job.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.crons.deleteThreads.name }}
+spec:
+  schedule: {{ .Values.crons.deleteThreads.schedule }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ .Values.crons.deleteThreads.name }}
+            image: radial/busyboxplus:curl
+            env:
+              - name: SECURITY_USER_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: security-credentials
+                    key: security-user
+              - name: SECURITY_USER_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: security-credentials
+                    key: security-password
+              - name: TARGET
+                value: {{ .Values.crons.deleteThreads.target }}
+            command:
+            - /bin/sh
+            - -c
+            - curl -s -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X PATCH http://$(SECURE_MESSAGE_V2_SERVICE_HOST):$(SECURE_MESSAGE_V2_SERVICE_PORT)/$(TARGET)
+          restartPolicy: OnFailure

--- a/_infra/helm/secure-message-v2/templates/mark-thread-for-deletion-scheduled-job.yaml
+++ b/_infra/helm/secure-message-v2/templates/mark-thread-for-deletion-scheduled-job.yaml
@@ -1,15 +1,15 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Values.crons.markThreadForDeletion.name }}
+  name: {{ .Values.crons.markThreadsForDeletion.name }}
 spec:
-  schedule: {{ .Values.crons.markThreadForDeletion.schedule }}
+  schedule: {{ .Values.crons.markThreadsForDeletion.schedule }}
   jobTemplate:
     spec:
       template:
         spec:
           containers:
-          - name: {{ .Values.crons.markThreadForDeletion.name }}
+          - name: {{ .Values.crons.markThreadsForDeletion.name }}
             image: radial/busyboxplus:curl
             env:
               - name: SECURITY_USER_NAME
@@ -23,7 +23,7 @@ spec:
                     name: security-credentials
                     key: security-password
               - name: TARGET
-                value: {{ .Values.crons.markThreadForDeletion.target }}
+                value: {{ .Values.crons.markThreadsForDeletion.target }}
             command:
             - /bin/sh
             - -c

--- a/_infra/helm/secure-message-v2/values.yaml
+++ b/_infra/helm/secure-message-v2/values.yaml
@@ -54,5 +54,9 @@ dns:
 crons:
   markThreadForDeletion:
     name: sm-v2-mark-thread-for-deletion-scheduled-job
-    schedule: "0 1 * * *"
+    schedule: "0 2 * * *"
     target: "batch/mark_thread_for_deletion"
+  deleteThreads:
+    name: sm-v2-delete-threads-scheduled-job
+    schedule: "0 1 * * *"
+    target: "batch/threads"

--- a/_infra/helm/secure-message-v2/values.yaml
+++ b/_infra/helm/secure-message-v2/values.yaml
@@ -52,7 +52,7 @@ dns:
   wellKnownPort: 8080
 
 crons:
-  markThreadForDeletion:
+  markThreadsForDeletion:
     name: sm-v2-mark-threads-for-deletion-scheduled-job
     schedule: "0 2 * * *"
     target: "batch/mark_threads_for_deletion"

--- a/_infra/helm/secure-message-v2/values.yaml
+++ b/_infra/helm/secure-message-v2/values.yaml
@@ -53,9 +53,9 @@ dns:
 
 crons:
   markThreadForDeletion:
-    name: sm-v2-mark-thread-for-deletion-scheduled-job
+    name: sm-v2-mark-threads-for-deletion-scheduled-job
     schedule: "0 2 * * *"
-    target: "batch/mark_thread_for_deletion"
+    target: "batch/mark_threads_for_deletion"
   deleteThreads:
     name: sm-v2-delete-threads-scheduled-job
     schedule: "0 1 * * *"

--- a/openapi.yml
+++ b/openapi.yml
@@ -11,6 +11,8 @@ tags:
     description: Message endpoints
   - name: Threads
     description: Thread endpoints
+  - name: Batch
+    description: Batch endpoints
   - name: Existing
     description: Existing secure message functionality
   - name: New
@@ -392,6 +394,24 @@ paths:
                     type: string
                     description: Health status of the service
                     example: OK
+  /batch/mark_thread_for_deletion:
+    patch:
+      tags:
+        - Batch
+      summary: patch for thread marked_for_deletion
+      description: patches marked_for_deletion to True if closed_at_date is less than a configurable date
+      responses:
+        '204':
+          description: successful operation
+  /batch/threads:
+    delete:
+      tags:
+        - Batch
+      summary: deletes threads
+      description: deletes all threads that have their marked_for_deletion set to True
+      responses:
+        '204':
+          description: successful operation
 components:
   schemas:
     Thread:

--- a/openapi.yml
+++ b/openapi.yml
@@ -394,12 +394,12 @@ paths:
                     type: string
                     description: Health status of the service
                     example: OK
-  /batch/mark_thread_for_deletion:
+  /batch/mark_threads_for_deletion:
     patch:
       tags:
         - Batch
-      summary: patch for thread marked_for_deletion
-      description: patches marked_for_deletion to True if closed_at_date is less than a configurable date
+      summary: patch for threads to marked_for_deletion
+      description: patches marked_for_deletion to True for all threads if closed_at_date is less than a configurable date
       responses:
         '204':
           description: successful operation

--- a/secure_message_v2/controllers/queries.py
+++ b/secure_message_v2/controllers/queries.py
@@ -39,3 +39,12 @@ def query_threads_marked_for_deletion_by_closed_at_date(date_threshold: datetime
         .filter(Thread.closed_at < date_threshold)
         .update({Thread.marked_for_deletion: True})
     )
+
+
+def query_delete_threads_marked_for_deletion(session: Session) -> int:
+    """
+    Deletes all threads marked_for_deletion
+    :param session
+    :return: a count of the threads updated
+    """
+    return session.query(Thread).where(Thread.marked_for_deletion.is_(True)).delete()

--- a/secure_message_v2/views/batch_requests.py
+++ b/secure_message_v2/views/batch_requests.py
@@ -5,7 +5,10 @@ from flask import Blueprint, current_app
 from flask_httpauth import HTTPBasicAuth
 from structlog import wrap_logger
 
-from secure_message_v2.controllers.threads import marked_for_deletion_by_closed_at_date
+from secure_message_v2.controllers.threads import (
+    delete_threads_marked_for_deletion,
+    marked_for_deletion_by_closed_at_date,
+)
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -26,4 +29,11 @@ def verify_password(username: str, password: str) -> Optional[str]:
 @auth.login_required
 def mark_thread_for_deletion() -> tuple[str, int]:
     marked_for_deletion_by_closed_at_date()
+    return "", 204
+
+
+@batch_request_bp.route("/threads", methods=["DELETE"])
+@auth.login_required
+def delete_threads() -> tuple[str, int]:
+    delete_threads_marked_for_deletion()
     return "", 204

--- a/secure_message_v2/views/batch_requests.py
+++ b/secure_message_v2/views/batch_requests.py
@@ -25,9 +25,9 @@ def verify_password(username: str, password: str) -> Optional[str]:
         return username
 
 
-@batch_request_bp.route("/mark_thread_for_deletion", methods=["PATCH"])
+@batch_request_bp.route("/mark_threads_for_deletion", methods=["PATCH"])
 @auth.login_required
-def mark_thread_for_deletion() -> tuple[str, int]:
+def mark_threads_for_deletion() -> tuple[str, int]:
     marked_for_deletion_by_closed_at_date()
     return "", 204
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,13 @@ def valid_closed_thread_ready_for_deletion(valid_closed_thread_payload):
 
 
 @pytest.fixture()
+def valid_marked_for_deletion(valid_closed_thread_ready_for_deletion):
+    marked_for_deletion = valid_closed_thread_ready_for_deletion.copy()
+    marked_for_deletion["marked_for_deletion"] = True
+    return marked_for_deletion
+
+
+@pytest.fixture()
 def invalid_thread_payload_missing_key(valid_thread_payload):
     thread_missing_key = valid_thread_payload.copy()
     thread_missing_key.pop("category")

--- a/tests/unit/views/test_batch_requests.py
+++ b/tests/unit/views/test_batch_requests.py
@@ -1,5 +1,12 @@
-def test_batch_mark_thread_for_deletion(test_client, mocker):
+def test_mark_thread_for_deletion(test_client, mocker):
     mocker.patch("secure_message_v2.views.batch_requests.marked_for_deletion_by_closed_at_date")
     response = test_client.patch("batch/mark_thread_for_deletion", auth=("admin", "secret"))
+
+    assert 204 == response.status_code
+
+
+def test_delete_threads_marked_for_deletion(test_client, mocker):
+    mocker.patch("secure_message_v2.views.batch_requests.delete_threads_marked_for_deletion")
+    response = test_client.delete("batch/threads", auth=("admin", "secret"))
 
     assert 204 == response.status_code

--- a/tests/unit/views/test_batch_requests.py
+++ b/tests/unit/views/test_batch_requests.py
@@ -1,6 +1,6 @@
-def test_mark_thread_for_deletion(test_client, mocker):
+def test_mark_threads_for_deletion(test_client, mocker):
     mocker.patch("secure_message_v2.views.batch_requests.marked_for_deletion_by_closed_at_date")
-    response = test_client.patch("batch/mark_thread_for_deletion", auth=("admin", "secret"))
+    response = test_client.patch("batch/mark_threads_for_deletion", auth=("admin", "secret"))
 
     assert 204 == response.status_code
 


### PR DESCRIPTION
# What and why?
This PR adds in the batch thread deletion endpoint and Cron job

# How to test?
Because there is chart change there is a little bit of prep work before this can be tested

You can either, remove the deployment of SM_v2 in the cluster spinnaker set-up or let it run then remove it

**Leaving the spinnaker job unchanged, you will need to do**
1. kubectl delete service secure-message-v2 --namespace <your namespace>
2. kubectl delete deployment secure-message-v2 --namespace <your namespace>
3. kubectl delete cronjob sm-v2-mark-thread-for-deletion-scheduled-job --namespace <your namespace>

**For both ways you now need to deploy SM_v2 from the terminal** (our setup in spinnaker builds from latest then overrides the code, this means charts are ignored, which is no good in this scenario) not forgetting to update the env, namespace and tag

```helm install secure-message-v2 ./_infra/helm/secure-message-v2```

You are now good to go. I generally add a couple of  threads in, 1 marked_for_deletion and 1 not 

You can do this straight in to the db, by the endpoint or now by the UI, the UI is easiest, but remember to update the marked_for_deletion in the db
