### PR TITLE
bump chart version

### DIFF
--- a/_infra/helm/secure-message-v2/Chart.yaml
+++ b/_infra/helm/secure-message-v2/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.24
+version: 0.0.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.24
+appVersion: 0.0.25


### PR DESCRIPTION
# What and why?
When I merged in my python version upgrade PR, the build failed because the chart version hadn't updated.