### PR TITLE
RAS-1346 Introduce structured logging config into secure-message-v2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,6 +27,7 @@ mypy = "*"
 pytest-cov = "*"
 requests-mock = "*"
 types-requests = "*"
+freezegun = "*"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2702d8fe48ed740f8955874b7f32f43ee2b3992cb3cda89abc3302224e0029f0"
+            "sha256": "7c1c572bc6cc919bddfd2607858dc5ae3e4c41eb298ebeb969aa0ae339729e37"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -808,6 +808,15 @@
             "markers": "python_full_version >= '3.8.1'",
             "version": "==7.1.1"
         },
+        "freezegun": {
+            "hashes": [
+                "sha256:b29dedfcda6d5e8e083ce71b2b542753ad48cfec44037b3fc79702e2980a89e9",
+                "sha256:bf111d7138a8abe55ab48a71755673dbaa4ab87f4cff5634a4442dfec34c15f1"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==1.5.1"
+        },
         "greenlet": {
             "hashes": [
                 "sha256:0153404a4bb921f0ff1abeb5ce8a5131da56b953eda6e14b88dc6bbc04d2049e",
@@ -1051,6 +1060,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.14.0"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.9.0.post0"
+        },
         "requests": {
             "hashes": [
                 "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
@@ -1068,6 +1085,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.5'",
             "version": "==1.12.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.16.0"
         },
         "sqlalchemy": {
             "hashes": [

--- a/_infra/helm/secure-message-v2/Chart.yaml
+++ b/_infra/helm/secure-message-v2/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.26
+version: 0.0.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.26
+appVersion: 0.0.27

--- a/config.py
+++ b/config.py
@@ -23,3 +23,4 @@ class Config:
     THREAD_DELETION_OFFSET_IN_DAYS = 365
     SECURITY_USER_PASSWORD = os.getenv("SECURITY_USER_PASSWORD", "secret")
     SECURITY_USER_NAME = os.getenv("SECURITY_USER_NAME", "admin")
+    LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO")

--- a/secure_message_v2/application.py
+++ b/secure_message_v2/application.py
@@ -9,6 +9,7 @@ from structlog import wrap_logger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from secure_message_v2.authentication.authentication import JWTValidationError
+from secure_message_v2.logger_config import logger_initial_config
 from secure_message_v2.models import models
 from secure_message_v2.views.batch_requests import batch_request_bp
 from secure_message_v2.views.info import info_bp
@@ -21,9 +22,10 @@ logger = wrap_logger(logging.getLogger(__name__))
 def create_app():
     app = Flask(__name__)
     app.name = "ras-rm-secure-message-v2"
-    logger.info("Creating app", name=app.name)
     app_config = "config.Config"
     app.config.from_object(app_config)
+    logger_initial_config(log_level=app.config["LOGGING_LEVEL"])
+    logger.info("Creating app", name=app.name)
 
     app.register_blueprint(info_bp, url_prefix="/info")
     app.register_blueprint(messages_bp, url_prefix="/messages")

--- a/secure_message_v2/controllers/messages.py
+++ b/secure_message_v2/controllers/messages.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 import structlog
 from sqlalchemy.orm import Session
@@ -25,7 +25,7 @@ def create_message(message_payload: dict, session: Session) -> Message:
         body=message_payload["body"],
         is_from_internal=message_payload["is_from_internal"],
         sent_by=message_payload["sent_by"],
-        sent_at=datetime.utcnow(),
+        sent_at=datetime.now(timezone.utc),
     )
     session.add(message)
     update_read_status(message_payload["thread_id"], message.is_from_internal, not message.is_from_internal, session)

--- a/secure_message_v2/logger_config.py
+++ b/secure_message_v2/logger_config.py
@@ -1,0 +1,36 @@
+import logging
+import sys
+
+import structlog
+
+
+def logger_initial_config(log_level: str = "INFO") -> None:
+    def add_severity_level(_, method_name: str, event_dict: dict) -> dict:
+        """
+        Adds the log level to the event dict.
+        """
+        event_dict["severity"] = method_name
+        return event_dict
+
+    def add_service(_, __, event_dict: dict) -> dict:
+        """
+        Adds the service name (secure-message-v2) to the event dict.
+        """
+        event_dict["service"] = "secure-message-v2"
+        return event_dict
+
+    logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.INFO)
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            add_severity_level,  # type: ignore
+            add_service,  # type: ignore
+            structlog.processors.format_exc_info,
+            structlog.processors.TimeStamper(fmt="%Y-%m-%dT%H:%M%s", utc=True, key="created_at"),
+            structlog.processors.JSONRenderer(indent=None),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.getLevelName(log_level)),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )

--- a/tests/test_logger_config.py
+++ b/tests/test_logger_config.py
@@ -1,0 +1,74 @@
+import json
+import logging
+from datetime import datetime, timezone
+
+from freezegun import freeze_time
+from structlog import wrap_logger
+
+from secure_message_v2.logger_config import logger_initial_config
+
+TIME_TO_FREEZE = datetime(2024, 1, 1, 12, 0, 0, 0, tzinfo=timezone.utc)
+
+EXPECTED_ERROR_OUTPUT = json.dumps(
+    {
+        "event": "Test error",
+        "severity": "error",
+        "service": "secure-message-v2",
+        "created_at": "2024-01-01T12:001704110400",
+    }
+)
+
+EXPECTED_INFO_OUTPUT = json.dumps(
+    {
+        "additional_key": "additional_value",
+        "event": "Test info",
+        "severity": "info",
+        "service": "secure-message-v2",
+        "created_at": "2024-01-01T12:001704110400",
+    }
+)
+
+EXPECTED_DEBUG_OUTPUT = json.dumps(
+    {
+        "event": "Test debug",
+        "severity": "debug",
+        "service": "secure-message-v2",
+        "created_at": "2024-01-01T12:001704110400",
+    }
+)
+
+
+@freeze_time(TIME_TO_FREEZE)
+def test_level_debug(caplog):
+    _generate_logs(caplog, "DEBUG")
+
+    assert len(caplog.messages) == 3
+    assert caplog.messages[0] == EXPECTED_ERROR_OUTPUT
+    assert caplog.messages[1] == EXPECTED_INFO_OUTPUT
+    assert caplog.messages[2] == EXPECTED_DEBUG_OUTPUT
+
+
+@freeze_time(TIME_TO_FREEZE)
+def test_level_info(caplog):
+    _generate_logs(caplog, "INFO")
+
+    assert len(caplog.messages) == 2
+    assert caplog.messages[0] == EXPECTED_ERROR_OUTPUT
+    assert caplog.messages[1] == EXPECTED_INFO_OUTPUT
+
+
+@freeze_time(TIME_TO_FREEZE)
+def test_level_error(caplog):
+    _generate_logs(caplog, "ERROR")
+
+    assert len(caplog.messages) == 1
+    assert caplog.messages[0] == EXPECTED_ERROR_OUTPUT
+
+
+def _generate_logs(caplog, log_level):
+    caplog.set_level(log_level)
+    logger_initial_config(log_level)
+    logger = wrap_logger(logging.getLogger())
+    logger.error("Test error")
+    logger.info("Test info", additional_key="additional_value")
+    logger.debug("Test debug")


### PR DESCRIPTION
# What and why?
Adds structlogs to repo
# How to test?
Deploy to GCP and check the logs come out in the correct format. A simple way to generate a log message is by firing one of the cron jobs, although you will also get the Creating app/database one on start up.

N.B the kube-probe needs quieting down at some stage, but is outside the scope of this story
# Jira