### PR TITLE
Fix bulk thread delete error in preprod

### DIFF
--- a/_infra/helm/secure-message-v2/Chart.yaml
+++ b/_infra/helm/secure-message-v2/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.27
+version: 0.0.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.27
+appVersion: 0.0.28

--- a/secure_message_v2/controllers/queries.py
+++ b/secure_message_v2/controllers/queries.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import and_
+from sqlalchemy import and_, delete
 from sqlalchemy.orm import Session
 
 from secure_message_v2.models.models import Thread
@@ -41,10 +41,10 @@ def query_threads_marked_for_deletion_by_closed_at_date(date_threshold: datetime
     )
 
 
-def query_delete_threads_marked_for_deletion(session: Session) -> int:
+def query_delete_threads_marked_for_deletion(session: Session) -> None:
     """
     Deletes all threads marked_for_deletion
     :param session
     :return: a count of the threads updated
     """
-    return session.query(Thread).where(Thread.marked_for_deletion.is_(True)).delete()
+    session.execute(delete(Thread).where(Thread.marked_for_deletion.is_(True)))

--- a/secure_message_v2/controllers/queries.py
+++ b/secure_message_v2/controllers/queries.py
@@ -47,6 +47,10 @@ def query_delete_threads_marked_for_deletion(session: Session) -> int:
     :param session
     :return: a count of the threads updated
     """
+
+    # ORM cascade behaviour only works for individual instances, it does not apply to “bulk” deletes as per the docs,
+    # Therefore we manually have to delete the messages first
+
     thread_ids_to_delete = session.query(Thread.id).filter(Thread.marked_for_deletion.is_(True))
     session.query(Message).where(Message.thread_id.in_(thread_ids_to_delete)).delete()
 

--- a/secure_message_v2/controllers/threads.py
+++ b/secure_message_v2/controllers/threads.py
@@ -128,4 +128,5 @@ def delete_threads_marked_for_deletion(session: Session) -> None:
     Deletes all threads marked_for_deletion
     :param session
     """
-    query_delete_threads_marked_for_deletion(session)
+    threads_updated = query_delete_threads_marked_for_deletion(session)
+    logger.info(f"{threads_updated} Threads deleted")

--- a/secure_message_v2/controllers/threads.py
+++ b/secure_message_v2/controllers/threads.py
@@ -128,5 +128,4 @@ def delete_threads_marked_for_deletion(session: Session) -> None:
     Deletes all threads marked_for_deletion
     :param session
     """
-    threads_updated = query_delete_threads_marked_for_deletion(session)
-    logger.info(f"{threads_updated} Threads deleted")
+    query_delete_threads_marked_for_deletion(session)


### PR DESCRIPTION
# What and why?
Bulk thread deletes fail in preprod due to how the model cascade works in postgres, this PR deletes the messages first that then allows the removal of the thread
# How to test?
This PR is in preprod already, run the cron delete jump and make sure it works. Equally test this fully by adding messages and threads, I generally add a couple of threads in, marked_for_deletion and not

You can do this straight in to the db, by the endpoint or now by the UI (frontstage sends both to sm v1 and v2), the UI is easiest, but remember to update the marked_for_deletion in the db
# Jira